### PR TITLE
Add redirect from integrations/frameworks to integrations/introduction

### DIFF
--- a/docs/integrations/frameworks.rst
+++ b/docs/integrations/frameworks.rst
@@ -1,0 +1,4 @@
+.. This is redirect to other page, see meta tag below
+
+.. meta::
+   :http-equiv=refresh: 0; introduction.html


### PR DESCRIPTION
I decided to make it via Sphinx "meta" directive to generate proper meta redirect tag.

It could be done on a HTTP server level (nginx) as a 301 redirect, however I think no one would remember to maintain it as it is more related to documentation content rather to server config.