### PR TITLE
Fix order in the list under the team workspace docs

### DIFF
--- a/docs/workspace-project-and-user-management/workspaces/index.rst
+++ b/docs/workspace-project-and-user-management/workspaces/index.rst
@@ -23,9 +23,9 @@ Team
 ^^^^
 
 * A team workspace comes in handy when an entire team needs to be managed centrally.
+* You can `request free Team trial <https://neptune-team-trial.paperform.co>`_ and we will create a Team workspace for you
 * Once :ref:`created <administration-create-workspace>`, a team workspace can be managed by the :ref:`workspace Admin <administration-user-roles-workspace>`. The admin can manage users and subscription settings.
 * Only users who joined team workspace can browse its content, subject to the assigned :ref:`role <administration-user-roles-project>` in the workspace or project.
-* You can `request free Team trial <https://neptune-team-trial.paperform.co>`_ and we will create a Team workspace for you
 
 Learn more about :ref:`project types <administration-project-types>` and :ref:`user roles <administration-user-roles>`.
 


### PR DESCRIPTION
Something went wrong when merging and releasing the last few PRs and the order has changed. This PR fixes it.